### PR TITLE
Android: Prevent app crash for targetSDK 31/Android 12

### DIFF
--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -483,7 +483,7 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
             Activity activity = getActivity();
             Intent intent = new Intent(activity, activity.getClass());
             intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            pendingIntent = PendingIntent.getActivity(activity, 0, intent, 0);
+            pendingIntent = PendingIntent.getActivity(activity, 0, intent, PendingIntent.FLAG_MUTABLE);
         }
     }
 


### PR DESCRIPTION
Force pending intent MUTABLE flag for Android 12
BREAKING CHANGE: requires Android build SDK ≥ 31, because of [FLAG_MUTABLE](https://developer.android.com/reference/android/app/PendingIntent#FLAG_MUTABLE) _added in API level 31_.

See upstream Issues https://github.com/chariotsolutions/phonegap-nfc/issues/465, https://github.com/chariotsolutions/phonegap-nfc/issues/476, and https://github.com/chariotsolutions/phonegap-nfc/issues/478
and Pull Requests https://github.com/chariotsolutions/phonegap-nfc/pull/466, https://github.com/chariotsolutions/phonegap-nfc/pull/474, and https://github.com/chariotsolutions/phonegap-nfc/pull/477